### PR TITLE
Overall scrap return modifier.

### DIFF
--- a/ThriftySmithing.csproj
+++ b/ThriftySmithing.csproj
@@ -42,12 +42,12 @@
     <Compile Remove="src/thrifty/debug/commands/*.cs"/>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.34.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+<!--  <ItemGroup>-->
+<!--    <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.34.2">-->
+<!--      <PrivateAssets>all</PrivateAssets>-->
+<!--      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>-->
+<!--    </PackageReference>-->
+<!--  </ItemGroup>-->
 
   <ItemGroup>
     <Folder Include="vendor\" />

--- a/docs/mod-db.html
+++ b/docs/mod-db.html
@@ -106,7 +106,7 @@
     </li>
     <li>
       Thrifty Smithing <em>may</em> be compatible with mod-based metals, assuming
-      they provide metal bit items with asset locations matching the base game’s
+      they provide metal bit items with asset locations matching the base game&apos;s
       <code>metalbit-{material}</code> scheme.
     </li>
     <li>

--- a/docs/mod-db.html
+++ b/docs/mod-db.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>Thrifty Smithing</title>
@@ -24,55 +25,73 @@
     base VintageStory experience.  Most of these should not be changed unless
     necessitated by changes from other mods.
   </p>
-  <pre class="language-javascript"><code>{
-  "voxelsPerIngot": 42,
-  "voxelsPerPlate": 81,
-  "materialUnitsPerIngot": 100,
-  "materialUnitsPerBit": 5,
-  "disallowedRecipes": []
+  <pre><code data-lang="json">{
+  <span style="color:#606"><span style="color:#404">&quot;</span><span>voxelsPerIngot</span><span style="color:#404">&quot;</span></span>: <span style="color:#00D">42</span>,
+  <span style="color:#606"><span style="color:#404">&quot;</span><span>voxelsPerPlate</span><span style="color:#404">&quot;</span></span>: <span style="color:#00D">81</span>,
+  <span style="color:#606"><span style="color:#404">&quot;</span><span>materialUnitsPerIngot</span><span style="color:#404">&quot;</span></span>: <span style="color:#00D">100</span>,
+  <span style="color:#606"><span style="color:#404">&quot;</span><span>materialUnitsPerBit</span><span style="color:#404">&quot;</span></span>: <span style="color:#00D">5</span>,
+  <span style="color:#606"><span style="color:#404">&quot;</span><span>materialUnitsRecoveredModifier</span><span style="color:#404">&quot;</span></span>: <span style="color:#60E">1.0</span>,
+  <span style="color:#606"><span style="color:#404">&quot;</span><span>disallowedRecipes</span><span style="color:#404">&quot;</span></span>: []
 }</code></pre>
-  <table style="border-spacing: 5px;">
+  <table>
     <thead>
       <tr>
-        <th>Option</th>
-        <th>Type</th>
-        <th>Description</th>
+        <th style="border-right: 1px black solid; padding: 5px;">Option</th>
+        <th style="border-right: 1px black solid; padding: 5px;">Type</th>
+        <th style="padding: 5px;">Description</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td><code>voxelsPerIngot</code></td>
-        <td><code>int</code> in <code>[1..255]</code></td>
-        <td>The number of voxels a single ingot should be worth.</td>
+        <td style="border-right: 1px black solid;padding: 5px;"><p><code>voxelsPerIngot</code></p></td>
+        <td style="border-right: 1px black solid;padding: 5px;"><p><code>int</code></p></td>
+        <td style="padding: 5px;">
+          <p>The number of voxels a single ingot should be worth.</p>
+          <p>Valid value range: <code>[1..255]</code></p>
+        </td>
       </tr>
       <tr>
-        <td><code>voxelsPerPlate</code></td>
-        <td><code>int</code> in <code>[1..255]</code></td>
-        <td>The number of voxels a single metal plate should be worth.</td>
+        <td style="border-right: 1px black solid;padding: 5px;"><p><code>voxelsPerPlate</code></p></td>
+        <td style="border-right: 1px black solid;padding: 5px;"><p><code>int</code></p></td>
+        <td style="padding: 5px;">
+          <p>The number of voxels a single metal plate should be worth.</p>
+          <p>Valid value range: <code>[1..255]</code></p>
+        </td>
       </tr>
       <tr>
-        <td><code>materialUnitsPerIngot</code></td>
-        <td><code>int</code> in <code>[1..65535]</code></td>
-        <td>The amount of material required to craft an ingot.</td>
+        <td style="border-right: 1px black solid;padding: 5px;"><p><code>materialUnitsPerIngot</code></p></td>
+        <td style="border-right: 1px black solid;padding: 5px;"><p><code>int</code></p></td>
+        <td style="padding: 5px;">
+          <p>The amount of material required to craft an ingot.</p>
+          <p>Valid value range: <code>[1..65535]</code></p>
+        </td>
       </tr>
       <tr>
-        <td><code>materialUnitsPerBit</code></td>
-        <td><code>int</code> in <code>[1..255]</code></td>
-        <td>The amount of material represented by a single metal bit.</td>
+        <td style="border-right: 1px black solid;padding: 5px;"><p><code>materialUnitsPerBit</code></p></td>
+        <td style="border-right: 1px black solid;padding: 5px;"><p><code>int</code></p></td>
+        <td style="padding: 5px;">
+          <p>The amount of material represented by a single metal bit.</p>
+          <p>Valid value range: <code>[1..255]</code></p>
+        </td>
       </tr>
       <tr>
-        <td><code>disallowedRecipes</code></td>
-        <td>array of <code>string</code></td>
-        <td>
-          <p>
-            Asset locations for recipes that should not reward any scrap on
-            completion.
-          </p>
-          <p>
-            For example setting this to <code>["game:knifeblade-copper"]</code>
-            would mean that players are not given any scrap metal back when
-            crafting a copper knife blade.
-          </p>
+        <td style="border-right: 1px black solid;padding: 5px;"><p><code>materialUnitsRecoveredModifier</code></p></td>
+        <td style="border-right: 1px black solid;padding: 5px;"><p><code>float</code></p></td>
+        <td style="padding: 5px;">
+          <p>Percentage multiplier used to modify the amount of scrap material returned on
+            completion of a smithing work.</p>
+          <p>The default value of <code>1.0</code> represents <code>100%</code>, a value of <code>0.75</code> would represent
+            <code>75%</code>, <code>0.5</code> for <code>50%</code> and so on.</p>
+          <p>Valid value range: <code>[0.0..1.0]</code> (max precision of ~4 digits)</p>
+        </td>
+      </tr>
+      <tr>
+        <td style="border-right: 1px black solid;padding: 5px;"><p><code>disallowedRecipes</code></p></td>
+        <td style="border-right: 1px black solid;padding: 5px;"><p>array of <code>string</code></p></td>
+        <td style="padding: 5px;">
+          <p>Asset locations for recipes that should not reward any scrap on completion.</p>
+          <p>For example setting this to <code>["game:knifeblade-copper"]</code> would mean that players
+            are not given any scrap metal back when crafting a copper knife blade.</p>
         </td>
       </tr>
     </tbody>

--- a/makefile
+++ b/makefile
@@ -60,11 +60,11 @@ DEBUG_OUT_DIR      := $(OUTPUT_ROOT)/$(PROFILE_DEBUG)
 DEBUG_ZIP_TARGET   := $(RELEASE_ROOT)/$(ZIP_NAME_BASE)-$(MOD_VERSION)-DEBUG.zip
 DEBUG_OUTPUT_FILES := $(foreach file,$(ASSEMBLY_NAME).dll $(ASSEMBLY_NAME).pdb,$(DEBUG_OUT_DIR)/$(file))
 
-.PHONY: debug-build
-debug-build: $(DEBUG_OUTPUT_FILES)
+.PHONY: dev-build
+dev-build: $(DEBUG_OUTPUT_FILES)
 
-.PHONY: debug-release
-debug-release: $(DEBUG_ZIP_TARGET)
+.PHONY: dev-release
+dev-release: $(DEBUG_ZIP_TARGET)
 
 $(DEBUG_ZIP_TARGET): $(DEBUG_OUTPUT_FILES) $(INCLUDED_FILES)
 	@rm -f $(DEBUG_ZIP_TARGET)

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-ASSEMBLY_NAME := $(shell cat build.csproj | tr -d '[:space:]' | sed 's/.*AssemblyName>\([^<]\+\).*/\1/')
+ASSEMBLY_NAME := $(shell cat ThriftySmithing.csproj | tr -d '[:space:]' | sed 's/.*AssemblyName>\([^<]\+\).*/\1/')
 MOD_VERSION   := $(shell (git describe --tags 2> /dev/null || echo 'v0.0.0') | cut -c2-)
 MOD_ID        := $(shell echo "$(ASSEMBLY_NAME)" | tr '[:upper:]' '[:lower:]')
 
@@ -74,7 +74,7 @@ $(DEBUG_ZIP_TARGET): $(DEBUG_OUTPUT_FILES) $(INCLUDED_FILES)
 
 $(DEBUG_OUTPUT_FILES): $(CSHARP_FILES)
 	@rm -rf $(DEBUG_OUT_DIR) $(INTER_ROOT)
-	@dotnet build build.csproj /p:Configuration=$(PROFILE_DEBUG)
+	@dotnet build ThriftySmithing.csproj /p:Configuration=$(PROFILE_DEBUG)
 
 #
 # Release Builds

--- a/readme.adoc
+++ b/readme.adoc
@@ -28,6 +28,7 @@ these should not be changed unless necessitated by changes from other mods.
   "voxelsPerPlate": 81,
   "materialUnitsPerIngot": 100,
   "materialUnitsPerBit": 5,
+  "materialUnitsRecoveredModifier": 1.0,
   "disallowedRecipes": []
 }
 ----
@@ -37,20 +38,38 @@ these should not be changed unless necessitated by changes from other mods.
 | Option | Type | Description
 
 | voxelsPerIngot
-| `int` in `[1..255]`
+| `int`
 | The number of voxels a single ingot should be worth.
 
+Valid value range: `[1..255]`
+
 | voxelsPerPlate
-| `int` in `[1..255]`
+| `int`
 | The number of voxels a single metal plate should be worth.
 
+Valid value range: `[1..255]`
+
 | materialUnitsPerIngot
-| `int` in `[1..65535]`
+| `int`
 | The amount of material required to craft an ingot.
 
+Valid value range: `[1..65535]`
+
 | materialUnitsPerBit
-| `int` in `[1..255]`
+| `int`
 | The amount of material represented by a single metal bit.
+
+Valid value range: `[1..255]`
+
+| materialUnitsRecoveredModifier
+| `float`
+| Percentage multiplier used to modify the amount of scrap material returned on
+completion of a smithing work.
+
+The default value of `1.0` represents `100%`, a value of `0.75` would represent
+`75%`, `0.5` for `50%` and so on.
+
+Valid value range: `[0.0..1.0]` (max precision of ~4 digits)
 
 | disallowedRecipes
 | array of `string`

--- a/src/ThriftySmithing/Data/Smithy.cs
+++ b/src/ThriftySmithing/Data/Smithy.cs
@@ -27,6 +27,8 @@ internal static class Smithy {
 
   public static int MaterialUnitsPerBit => ThriftySmithing.Config.materialUnitsPerBit;
 
+  public static float MaterialUnitsRecoveredModifier => (float) ThriftySmithing.Config.materialUnitsRecoveredModifier;
+
   internal static bool recipeIsAllowed(SmithingRecipe recipe) =>
     recipe.Output != null
     && !ThriftySmithing.Config.disallowedRecipes.Contains(recipe.Output.Code.ToString());
@@ -74,7 +76,7 @@ internal static class Smithy {
     calculateInputVoxels(data) - getVoxelCount(recipe);
 
   private static float calculateWasteMaterial(WorkData data, SmithingRecipe recipe) =>
-    calculateWasteVoxels(data, recipe) * MaterialUnitsPerVoxel;
+    calculateWasteVoxels(data, recipe) * MaterialUnitsPerVoxel * MaterialUnitsRecoveredModifier;
 
   private static float calculateTotalInputMaterial(WorkData data) =>
     data.ingotCount * MaterialUnitsPerIngot + data.plateCount * MaterialUnitsPerPlate;

--- a/src/ThriftySmithing/Hax/BlockAnvilHax.cs
+++ b/src/ThriftySmithing/Hax/BlockAnvilHax.cs
@@ -12,8 +12,6 @@ namespace ThriftySmithing.Hax;
 [SuppressMessage("ReSharper", "UnusedType.Global")]
 internal class BlockAnvilHax {
 
-  private static ILogger logger => ThriftySmithing.Logger;
-
   [HarmonyPrefix]
   [SuppressMessage("ReSharper", "UnusedMember.Local")]
   private static void prefix(
@@ -29,7 +27,7 @@ internal class BlockAnvilHax {
 
     // If the entity is not an anvil entity??? then bail.
     if (world.BlockAccessor.GetBlockEntity(blockSel.Position) is not BlockEntityAnvil) {
-      logger.Debug("block wasn't an anvil entity?");
+      Logs.debug("block wasn't an anvil entity?");
       return;
     }
 
@@ -93,7 +91,7 @@ internal class BlockAnvilHax {
     //
     // TODO: Is it possible that a player can put down multiple items in a single shift-click?
     else if (!__state.code.Equals(stack?.Item?.Code)) {
-      logger.Debug("couldn't tell what was going on with that anvil interaction, ignoring it");
+      Logs.debug("couldn't tell what was going on with that anvil interaction, ignoring it");
       return;
     }
 
@@ -126,7 +124,7 @@ internal class BlockAnvilHax {
 
       case ItemType.Irrelevant:
       default:
-        logger.Warning("something fishy is afoot in the BlockAnvil.OnBlockInteractStart patch");
+        Logs.warn("something fishy is afoot in the BlockAnvil.OnBlockInteractStart patch");
         return;
     }
 

--- a/src/ThriftySmithing/Hax/BlockEntityAnvilHax.cs
+++ b/src/ThriftySmithing/Hax/BlockEntityAnvilHax.cs
@@ -21,9 +21,6 @@ namespace ThriftySmithing.Hax;
 [SuppressMessage("ReSharper", "UnusedType.Global")]
 internal class BlockEntityAnvilHax {
 
-
-  private static ILogger logger => ThriftySmithing.Logger;
-
   /**
    * <summary>
    * Before a voxel is split from a smithing recipe, if it is metal, add it to

--- a/src/ThriftySmithing/ThriftySmithing.cs
+++ b/src/ThriftySmithing/ThriftySmithing.cs
@@ -13,8 +13,6 @@ public class ThriftySmithing : ModSystem {
 
   private static ThriftySmithingConfig? loadedConfig;
 
-  private static ILogger? logger;
-
   #region Mod Internal
 
   internal const string WorkDataKey = "ef:ts:workData";
@@ -25,14 +23,10 @@ public class ThriftySmithing : ModSystem {
     loadedConfig ??
     throw new InvalidOperationException("attempted to get the ThriftySmithing mod configuration before it was loaded");
 
-  internal static ILogger Logger =>
-    logger ??
-    throw new InvalidOperationException("attempted to get the mod logger configuration before ThriftySmithing was started");
-
   #endregion Mod Internal
 
   public override void Start(ICoreAPI api) {
-    logger = Mod.Logger;
+    Logs.init(Mod.Logger);
 
     registerTypes();
     loadConfig(api);
@@ -48,23 +42,23 @@ public class ThriftySmithing : ModSystem {
       var configJSON = api.LoadModConfig(ConfigFileName);
 
       if (configJSON == null) {
-        Logger.Notification("no config file found, one will be generated");
+        Logs.info("no config file found, one will be generated");
         loadedConfig = ThriftySmithingConfig.defaultConfig();
         writeConfig = true;
       } else {
-        Logger.Debug("loaded mod configuration");
+        Logs.debug("loaded mod configuration");
         (loadedConfig, writeConfig) = ThriftySmithingConfig.parseFromJSON(configJSON);
       }
     } catch (Exception e) {
-      Logger.Error("failed to load config JSON: {0}", e.Message);
+      Logs.error("failed to load config JSON: {0}", e.Message);
       loadedConfig = ThriftySmithingConfig.defaultConfig();
       writeConfig = true;
     }
 
     if (writeConfig) {
       try {
-        Logger.Notification("writing configuration to file: {0}", ConfigFileName);
-        api.StoreModConfig(loadedConfig.Value.toJSON(), ConfigFileName);
+        Logs.info("writing configuration to file: {0}", ConfigFileName);
+        api.StoreModConfig(loadedConfig.toJSON(), ConfigFileName);
       } catch (Exception e) {
         Console.WriteLine(e);
         throw;

--- a/src/ThriftySmithing/Utils/Cereal.cs
+++ b/src/ThriftySmithing/Utils/Cereal.cs
@@ -1,0 +1,56 @@
+using System;
+using Newtonsoft.Json.Linq;
+
+namespace ThriftySmithing.Utils;
+
+internal static class Cereal {
+  internal static class JSON {
+    internal static (Half value, bool wasValid) tryParseHalf(JToken json, string key, Half defaultValue) {
+      var (f, b) = tryParseFloat(json, key, 0);
+      return b ? ((Half) f, true) : (defaultValue, false);
+    }
+
+    internal static (float value, bool wasValid) tryParseFloat(JToken json, string key, float defaultValue) {
+      if (json[key] == null)
+        return (defaultValue, false);
+
+      var value = json[key]!;
+
+      switch (value.Type) {
+        case JTokenType.Float:
+          return tryUnpackFloat(value, defaultValue);
+
+        case JTokenType.Integer:
+          var (i, b) = tryUnpackInt(value, 0);
+
+          if (!b)
+            return (defaultValue, false);
+
+          try {
+            return (i, true);
+          } catch (OverflowException) {
+            return (defaultValue, false);
+          }
+
+        default:
+          return (defaultValue, false);
+      }
+    }
+
+    private static (float value, bool wasValid) tryUnpackFloat(JToken raw, float defaultValue) {
+      try {
+        return (raw.Value<float>(), true);
+      } catch (OverflowException) {
+        return (defaultValue, false);
+      }
+    }
+
+    private static (int value, bool wasValid) tryUnpackInt(JToken raw, int defaultValue) {
+      try {
+        return (raw.Value<int>(), true);
+      } catch (OverflowException) {
+        return (defaultValue, false);
+      }
+    }
+  }
+}

--- a/src/ThriftySmithing/Utils/Logs.cs
+++ b/src/ThriftySmithing/Utils/Logs.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Vintagestory.API.Common;
+
+namespace thrifty.debug;
+
+internal static class Logs {
+  private static ILogger? logger;
+
+  #if ENABLE_DEBUG_FEATURES
+  private const string TracePattern = "{0}: {1}";
+  #endif
+
+  internal static void init(ILogger logger) {
+    Logs.logger = logger;
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  internal static void trace(string message) {
+    #if ENABLE_DEBUG_FEATURES
+    var frame = new StackFrame(1);
+    logger!.VerboseDebug(TracePattern, frame.GetMethod()!.Name, message);
+    #endif
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  internal static void trace(string format, object p1) {
+    #if ENABLE_DEBUG_FEATURES
+    var frame = new StackFrame(1);
+    logger!.VerboseDebug(TracePattern, frame.GetMethod()!.Name, string.Format(format, p1));
+    #endif
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  internal static void trace(string format, object p1, object p2) {
+    #if ENABLE_DEBUG_FEATURES
+    var frame = new StackFrame(1);
+    logger!.VerboseDebug(TracePattern, frame.GetMethod()!.Name, string.Format(format, p1, p2));
+    #endif
+  }
+
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  internal static void debug(string message) {
+    #if ENABLE_DEBUG_FEATURES
+    logger!.Debug(message);
+    #endif
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  internal static void debug(string format, object p1) {
+    #if ENABLE_DEBUG_FEATURES
+    logger!.Debug(format, p1);
+    #endif
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  internal static void debug(string format, object p1, object p2) {
+    #if ENABLE_DEBUG_FEATURES
+    logger!.Debug(format, p1, p2);
+    #endif
+  }
+
+  internal static void info(string format, params object[] things) => logger!.Notification(format, things);
+
+  internal static void warn(string message) => logger!.Warning(message);
+  internal static void warn(string format, params object[] things) => logger!.Warning(format, things);
+
+  internal static void error(string format, params object[] things) => logger!.Error(format, things);
+  internal static void error(Exception err) => logger!.Error(err);
+}

--- a/src/ThriftySmithing/Utils/Logs.cs
+++ b/src/ThriftySmithing/Utils/Logs.cs
@@ -3,8 +3,11 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Vintagestory.API.Common;
 
-namespace thrifty.debug;
+namespace ThriftySmithing.Utils;
 
+/// <summary>
+/// Logging facade.
+/// </summary>
 internal static class Logs {
   private static ILogger? logger;
 

--- a/src/ThriftySmithing/Utils/ThriftySmithingConfig.cs
+++ b/src/ThriftySmithing/Utils/ThriftySmithingConfig.cs
@@ -284,6 +284,7 @@ internal class ThriftySmithingConfig {
     if (murm < Half.Zero || murm > Half.One) {
       Logs.warn("config value \"" + ConfigKeyMaterialUnitsRecoveredModifier + "\" was outside the valid range; using default value");
       murm = (Half) DefaultMaterialUnitsRecoveredModifier;
+      tempWasValid = false;
     }
     wasValid = wasValid && tempWasValid;
 

--- a/src/ThriftySmithing/Utils/ThriftySmithingConfig.cs
+++ b/src/ThriftySmithing/Utils/ThriftySmithingConfig.cs
@@ -281,6 +281,10 @@ internal class ThriftySmithingConfig {
     (murm, tempWasValid) = Cereal.JSON.tryParseHalf(json.Token, ConfigKeyMaterialUnitsRecoveredModifier, (Half) DefaultMaterialUnitsRecoveredModifier);
     if (!tempWasValid)
       Logs.warn("config value \"" + ConfigKeyMaterialUnitsRecoveredModifier + "\" was invalid or absent; using default value");
+    if (murm < Half.Zero || murm > Half.One) {
+      Logs.warn("config value \"" + ConfigKeyMaterialUnitsRecoveredModifier + "\" was outside the valid range; using default value");
+      murm = (Half) DefaultMaterialUnitsRecoveredModifier;
+    }
     wasValid = wasValid && tempWasValid;
 
     (dr, tempWasValid) = parseDisallowedRecipes(json.Token);

--- a/src/ThriftySmithing/Utils/ThriftySmithingConfig.cs
+++ b/src/ThriftySmithing/Utils/ThriftySmithingConfig.cs
@@ -221,6 +221,7 @@ internal class ThriftySmithingConfig {
     json[ConfigKeyVoxelsPerPlate] = voxelsPerPlate;
     json[ConfigKeyMaterialUnitsPerIngot] = materialUnitsPerIngot;
     json[ConfigKeyMaterialUnitsPerBit] = materialUnitsPerBit;
+    json[ConfigKeyMaterialUnitsRecoveredModifier] = (float) materialUnitsRecoveredModifier;
     json[ConfigKeyDisallowedRecipes] = new JArray(disallowedRecipes);
 
     return new(json);
@@ -253,39 +254,39 @@ internal class ThriftySmithingConfig {
    * boolean value indicating whether the input JSON was valid.
    * </returns>
    */
-  internal static (ThriftySmithingConfig config, bool wasValid) parseFromJSON(JsonObject json) {
+  internal static (ThriftySmithingConfig config, bool writeConfig) parseFromJSON(JsonObject json) {
     if (json.Token.Type != JTokenType.Object) {
       Logs.warn("configuration JSON was not an object; using default config");
       return (defaultConfig(), false);
     }
 
-    bool wasValid = true, twv;
+    bool wasValid = true, tempWasValid;
     byte vpi, vpp, mupb;
     ushort mupi;
     Half murm;
     IReadOnlySet<string> dr;
 
-    (vpi, twv) = parseByte(json.Token, ConfigKeyVoxelsPerIngot, DefaultVoxelsPerIngot);
-    wasValid = wasValid && twv;
+    (vpi, tempWasValid) = parseByte(json.Token, ConfigKeyVoxelsPerIngot, DefaultVoxelsPerIngot);
+    wasValid = wasValid && tempWasValid;
 
-    (vpp, twv) = parseByte(json.Token, ConfigKeyVoxelsPerPlate, DefaultVoxelsPerPlate);
-    wasValid = wasValid && twv;
+    (vpp, tempWasValid) = parseByte(json.Token, ConfigKeyVoxelsPerPlate, DefaultVoxelsPerPlate);
+    wasValid = wasValid && tempWasValid;
 
-    (mupi, twv) = parseUShort(json.Token, ConfigKeyMaterialUnitsPerIngot, DefaultMaterialUnitsPerIngot);
-    wasValid = wasValid && twv;
+    (mupi, tempWasValid) = parseUShort(json.Token, ConfigKeyMaterialUnitsPerIngot, DefaultMaterialUnitsPerIngot);
+    wasValid = wasValid && tempWasValid;
 
-    (mupb, twv) = parseByte(json.Token, ConfigKeyMaterialUnitsPerBit, DefaultMaterialUnitsPerBit);
-    wasValid = wasValid && twv;
+    (mupb, tempWasValid) = parseByte(json.Token, ConfigKeyMaterialUnitsPerBit, DefaultMaterialUnitsPerBit);
+    wasValid = wasValid && tempWasValid;
 
-    (murm, twv) = Cereal.JSON.tryParseHalf(json.Token, ConfigKeyMaterialUnitsRecoveredModifier, (Half) DefaultMaterialUnitsRecoveredModifier);
-    if (!twv)
+    (murm, tempWasValid) = Cereal.JSON.tryParseHalf(json.Token, ConfigKeyMaterialUnitsRecoveredModifier, (Half) DefaultMaterialUnitsRecoveredModifier);
+    if (!tempWasValid)
       Logs.warn("config value \"" + ConfigKeyMaterialUnitsRecoveredModifier + "\" was invalid or absent; using default value");
-    wasValid = wasValid && twv;
+    wasValid = wasValid && tempWasValid;
 
-    (dr, twv) = parseDisallowedRecipes(json.Token);
-    wasValid = wasValid && twv;
+    (dr, tempWasValid) = parseDisallowedRecipes(json.Token);
+    wasValid = wasValid && tempWasValid;
 
-    return (new ThriftySmithingConfig(vpi, vpp, mupi, mupb, murm, dr), wasValid);
+    return (new ThriftySmithingConfig(vpi, vpp, mupi, mupb, murm, dr), !wasValid);
   }
 
   /**


### PR DESCRIPTION
## Features

* Adds a new config option for an overall modifier which can be used to alter the amount of scrap material rewarded on completion of a work.

## Fixes

* Issue causing config to be overwritten even though it was valid.

## Internals

* Incorporated new logger facade from rewrite branch
* Start moving serialization logic into its own static container class.